### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,20 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="27e2", GROUP="plug
   - To do this, go to the site packages directory of your pyenv install (ie. `$HOME/.pyenv/versions/3.9.7/lib/python3.9/site-packages`) and create an file named `homebrew.pth` containing the path for Homebrew Python's site packages directory (ie. `/opt/homebrew/lib/python3.9/site-packages`)
   - For example, for M1, it would be: `cd $HOME/.pyenv/versions/3.9.7/lib/python3.9/site-packages && echo "/opt/homebrew/lib/python3.9/site-packages" >> homebrew.pth`
 * Clone this repository to desired directory and change your working directory to the cloned repository
-* Create a virtualenv and activate it. Note that your python path will be different if not on M1. (`pyenv virtualenv --system-site-packages --python=/opt/homebrew/bin/python3 nut && source activate nut`)
+* Create a virtualenv and activate it. Note that your python path will be different if not on M1. (`pyenv virtualenv --system-site-packages --python=/opt/homebrew/bin/python3 nut && source activate nut`), for this command you should check the name of python's binary file, it could be python3.9 not python3.
 * Install wheel (`pip install wheel`)
 * Install pycurl using the below.
 ```
 on M1:
-PYCURL_SSL_LIBRARY=openssl LDFLAGS="-L/opt/homebrew/opt/openssl/lib" CPPFLAGS="-I/opt/homebrew/opt/openssl/include" pip install pycurl
+export PYCURL_SSL_LIBRARY=openssl\ 
+export LDFLAGS="-L/opt/homebrew/opt/openssl/lib"\
+export CPPFLAGS="-I/opt/homebrew/opt/openssl/include"\
+pip install pycurl
 on Intel:
-PYCURL_SSL_LIBRARY=openssl LDFLAGS="-L/usr/local/opt/openssl/lib" CPPFLAGS="-I/usr/local/opt/openssl/include" pip install pycurl --compile --no-cache-dir
+export PYCURL_SSL_LIBRARY=openssl\ 
+export LDFLAGS="-L/usr/local/opt/openssl/lib"\
+export CPPFLAGS="-I/usr/local/opt/openssl/include"\
+pip install pycurl --compile --no-cache-dir
 ```
 * Install all other dependencies (`pip install -r requirements.txt`)
 * Run `python nut.py` for CLI. Run `python3 nut_gui.py` to launch the application (this will *only* work if PyQT from Homebrew was succesfully installed via directions above)


### PR DESCRIPTION
add clarify on python version when creating virtual env, also add export before each env variables so that it will get recognize properly before install pycurl.

test spec: macbook pro m1 